### PR TITLE
import only parts of ramda needed for file size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,20 @@
-import R from 'ramda'
+import {
+  uncurryN,
+  pipe,
+  addIndex,
+  map,
+  zip,
+  sortBy,
+  prop,
+  transpose,
+} from 'ramda'
 
-export default R.uncurryN(2, (rank) =>
-  R.pipe(
-    R.addIndex(R.map)((element, idx) => [element, idx]),
-    R.zip(rank),
-    R.sortBy(R.prop(0)),
-    R.map(R.prop(1)),
-    R.transpose
+export default uncurryN(2, (rank) =>
+  pipe(
+    addIndex(map)((element, idx) => [element, idx]),
+    zip(rank),
+    sortBy(prop(0)),
+    map(prop(1)),
+    transpose
   )
 )

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import {
-  uncurryN,
-  pipe,
   addIndex,
   map,
-  zip,
-  sortBy,
+  pipe,
   prop,
+  sortBy,
   transpose,
+  uncurryN,
+  zip,
 } from 'ramda'
 
 export default uncurryN(2, (rank) =>


### PR DESCRIPTION
this results in a smaller compiled module, and only imports what we need from ramda.