### PR TITLE
refactor: keep default export but deprecate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,6 @@ export const curried =
 // to just being one exported function with an optional second
 // param... but this is just simpler.
 export const unwind = <T>(rank: number[], src: T[]) => curried(rank)(src)
+
+// deprecated, will be removed in version 4
+export default unwind


### PR DESCRIPTION
In #566 this was removed, but if I keep it around and just don't use it, that might be better