### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
     "husky": "9.1.7",
     "jest": "30.4.2",
     "tsup": "8.5.1",
-    "typescript": "5.9.3",
-    "typescript-eslint": "8.59.3",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.4",
     "lint-staged": "17.0.5",
     "prettier": "3.8.3",
-    "ts-jest": "29.4.9"
+    "ts-jest": "29.4.11"
   },
   "homepage": "https://github.com/philihp/sort-unwind#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sort"
   ],
   "devDependencies": {
+    "@eslint/js": "10.0.1",
     "@philihp/prettier-config": "1.0.0",
     "@tsconfig/recommended": "1.0.13",
     "@types/jest": "30.0.0",
@@ -44,12 +45,12 @@
     "fast-shuffle": "6.1.1",
     "husky": "9.1.7",
     "jest": "30.4.2",
-    "tsup": "8.5.1",
-    "typescript": "6.0.3",
-    "typescript-eslint": "8.59.4",
     "lint-staged": "17.0.5",
     "prettier": "3.8.3",
-    "ts-jest": "29.4.11"
+    "ts-jest": "29.4.11",
+    "tsup": "8.5.1",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.4"
   },
   "homepage": "https://github.com/philihp/sort-unwind#readme",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  },
   "include": [
     "./src/**/*"
   ]


### PR DESCRIPTION
## Summary
Bumps all outdated devDependencies to their latest versions:

- `typescript` 5.9.3 → 6.0.3
- `typescript-eslint` 8.59.3 → 8.59.4
- `ts-jest` 29.4.9 → 29.4.11

TypeScript 6.0 emits a deprecation warning for the `baseUrl` option (which tsup passes internally during DTS build). Added `"ignoreDeprecations": "6.0"` to `tsconfig.json` to silence the error and let the DTS build complete.

All other dependencies were already at their latest versions per `npm-check-updates`.

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` succeeds (CJS + ESM + DTS)
- [x] `npm test` — all 8 tests pass
- [ ] `npm run lint` — fails with `Cannot find package '@eslint/js'`, but this is a pre-existing issue unrelated to these bumps (`@eslint/js` is imported from `eslint.config.js` but not listed in `devDependencies`)


---
_Generated by [Claude Code](https://claude.ai/code/session_012aqMgbt2UthfmDYXbk57KY)_