### PR TITLE
fix(build): order exports types-first to eliminate esbuild warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added missing `@eslint/js` devDependency, which is imported by `eslint.config.js`.
+- Reordered `package.json` `exports` to put `types` first (per-format) so it isn't shadowed by `import`/`require`. Eliminates the esbuild "condition will never be used" warning during `tsup` builds and routes CJS consumers to `dist/index.d.cts`.
 
 ## [3.1.0] - 2024-07-20
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
   "main": "./dist/index.cjs",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
Eliminates the `tsup` build warnings:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]
```

esbuild matches `exports` conditions top-down, so listing `"types"` after `"import"` and `"require"` meant it could never match. Reordered to put `types` first, nested per format, so:

- ESM consumers get `dist/index.d.ts`
- CJS consumers get `dist/index.d.cts` (already emitted by tsup, but was never referenced)

## Test plan
- [x] `npm run build` — no warnings
- [x] `npm run lint` clean
- [x] `npm test` — 8/8 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_012aqMgbt2UthfmDYXbk57KY)_