### PR TITLE
Replace jest with the built-in node:test runner

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,6 @@
 import eslint from '@eslint/js'
-import jestPlugin from 'eslint-plugin-jest'
 import tseslint from 'typescript-eslint'
-import eslintConfigPrettier from "eslint-config-prettier";
+import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default tseslint.config(
   {
@@ -9,11 +8,7 @@ export default tseslint.config(
   },
   {
     files: ['src/**/*.ts'],
-    extends: [
-      eslint.configs.recommended,
-      eslintConfigPrettier,
-      ...tseslint.configs.recommended
-    ],
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended, eslintConfigPrettier],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': [
@@ -25,9 +20,5 @@ export default tseslint.config(
         },
       ],
     },
-  },
-  {
-    files: ['src/**/__tests__/*.ts', 'src/**/*.test.ts'],
-    extends: [jestPlugin.configs['flat/recommended']],
   }
 )

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-export default {
-  modulePathIgnorePatterns: ['<rootDir>/dist/'],
-  transform: {
-    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { module: 'commonjs' } }],
-  },
-}

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "build": "tsup",
     "lint": "eslint .",
     "prepare": "husky && npm run build",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "test:coverage": "mkdir -p coverage && node --experimental-strip-types --test --experimental-test-coverage --test-coverage-exclude='src/**/*.test.ts' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'src/**/*.test.ts'",
+    "test:watch": "node --experimental-strip-types --test --watch 'src/**/*.test.ts'"
   },
   "files": [
     "dist"
@@ -41,16 +41,13 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@philihp/prettier-config": "1.0.0",
-    "@types/jest": "30.0.0",
+    "@types/node": "25.9.2",
     "eslint": "10.4.1",
     "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-jest": "29.15.2",
     "fast-shuffle": "6.2.0",
     "husky": "9.1.7",
-    "jest": "30.4.2",
     "lint-staged": "17.0.7",
     "prettier": "3.8.3",
-    "ts-jest": "29.4.11",
     "tsup": "8.5.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.1"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,82 +1,76 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
 import { shuffle } from 'fast-shuffle'
-import { unwind, curried } from '..'
+import { curried, unwind } from '../index.ts'
 
 describe('unwind', () => {
   it('accepts zero items', () => {
-    expect.assertions(2)
     const src: any[] = []
     const rank: number[] = []
     const [dst, derank] = unwind(rank, src)
-    expect(dst).toStrictEqual([])
-    expect(derank).toStrictEqual([])
+    assert.deepEqual(dst, [])
+    assert.deepEqual(derank, [])
   })
 
   it('accepts 1 item', () => {
-    expect.assertions(2)
     const src = ['a']
     const rank = [0]
     const [dst, derank] = unwind(rank, src)
-    expect(dst).toStrictEqual(['a'])
-    expect(derank).toStrictEqual([0])
+    assert.deepEqual(dst, ['a'])
+    assert.deepEqual(derank, [0])
   })
 
   it('accepts 2 items', () => {
-    expect.assertions(2)
     const src = ['b', 'a']
     const rank = [1, 0]
     const [dst, derank] = unwind(rank, src)
-    expect(dst).toStrictEqual(['a', 'b'])
-    expect(derank).toStrictEqual([1, 0])
+    assert.deepEqual(dst, ['a', 'b'])
+    assert.deepEqual(derank, [1, 0])
   })
 
   it('accepts 3 items', () => {
-    expect.assertions(2)
     const src = ['b', 'c', 'a']
     const rank = [1, 2, 0]
     const [dst, derank] = unwind(rank, src)
-    expect(dst).toStrictEqual(['a', 'b', 'c'])
-    expect(derank).toStrictEqual([2, 0, 1])
+    assert.deepEqual(dst, ['a', 'b', 'c'])
+    assert.deepEqual(derank, [2, 0, 1])
   })
 
   it('accepts 4 items', () => {
-    expect.assertions(2)
     const src: string[] = ['b', 'd', 'c', 'a']
     const rank: number[] = [1, 3, 2, 0]
     const [dst, derank] = unwind(rank, src)
-    expect(dst).toStrictEqual(['a', 'b', 'c', 'd'])
-    expect(derank).toStrictEqual([3, 0, 2, 1])
+    assert.deepEqual(dst, ['a', 'b', 'c', 'd'])
+    assert.deepEqual(derank, [3, 0, 2, 1])
   })
 
   it('can undo the ranking', () => {
-    expect.assertions(3)
     const oneToAHundred = [...new Array(100)].map((_, i) => i)
     const src: any[] = shuffle(oneToAHundred)
     const rank: number[] = shuffle(oneToAHundred)
     const [trans, derank] = unwind(rank, src)
     const [dst, dederank] = unwind(derank, trans)
-    expect(src).toStrictEqual(dst)
-    expect(src).not.toBe(dst)
-    expect(dederank).not.toBe(rank)
+    assert.deepEqual(dst, src)
+    assert.notEqual(dst, src)
+    assert.notEqual(dederank, rank)
   })
 
   it('can be curried', () => {
-    expect.assertions(4)
     const reverse4 = curried([3, 2, 1, 0])
-    expect(() => {
+    assert.doesNotThrow(() => {
       const [reversed] = reverse4(['d', 'c', 'b', 'a'])
-      expect(reversed).toStrictEqual(['a', 'b', 'c', 'd'])
-    }).not.toThrow()
-    expect(() => {
+      assert.deepEqual(reversed, ['a', 'b', 'c', 'd'])
+    })
+    assert.doesNotThrow(() => {
       const [reversed] = reverse4(['d', 'd', 'b', 'b'])
-      expect(reversed).toStrictEqual(['b', 'b', 'd', 'd'])
-    }).not.toThrow()
+      assert.deepEqual(reversed, ['b', 'b', 'd', 'd'])
+    })
   })
 
   it('allows ranks that are not zero-indexed integers', () => {
-    expect.assertions(1)
     const src = ['a', 'b', 'c', 'd', 'e', 'f']
     const rank = [0.28591, 0.42682, 0.35912, 0.21237, 0.60619, 0.47078]
     const [dst] = unwind(rank, src)
-    expect(dst).toStrictEqual(['d', 'a', 'c', 'b', 'f', 'e'])
+    assert.deepEqual(dst, ['d', 'a', 'c', 'b', 'f', 'e'])
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["jest"]
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Replaces jest with Node's built-in test runner (`node:test`), removing four devDependencies and the jest config file, and simplifies the eslint config now that the jest plugin is gone.

### Test runner
- Tests are rewritten against `node:test` (`describe`/`it`) and `node:assert/strict`, preserving every existing case and assertion. The `expect.assertions(n)` calls had no `node:test` equivalent and were dropped — all tests are synchronous, so they weren't guarding anything.
- The import in the test file changed from `'..'` to `'../index.ts'`: Node ESM has no directory imports (that only worked under jest's CJS resolution). `allowImportingTsExtensions` was added to tsconfig to match.
- Scripts run via `node --experimental-strip-types --test`. The flag is required on Node 22 (the oldest supported line) and harmless on 24/26 where type stripping is on by default.
- `jest.config.js` is deleted; `jest`, `ts-jest`, `@types/jest`, and `eslint-plugin-jest` are removed. `@types/node` is now an explicit devDependency for the `node:test` / `node:assert` types.

### Coverage
- `test:coverage` uses the runner's built-in coverage with the lcov reporter writing to `coverage/lcov.info` — the path the Coveralls action already reads — plus a spec reporter to stdout so CI logs stay readable. Test files are excluded from the report. No workflow changes needed.

### eslint cleanup
- Removed the jest plugin import and the test-file override block, collapsing the config to a single block for all of `src/`.
- Moved `eslint-config-prettier` to the end of `extends`, where it can actually disable conflicting rules (it was previously ordered before the typescript-eslint configs).

## Verification (local, Node 22.22.2 — the strictest supported line)
- `npm test` — 8/8 passing
- `npm run test:coverage` — 100% lines/branches/functions, `coverage/lcov.info` generated
- `npm run lint`, `npx tsc --noEmit`, `npm run build` — all clean, `.d.ts`/`.d.cts` still emitted

https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX)_