### PR TITLE
Add release workflow using npm stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # for npm provenance attestation
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version # node 26 bundles npm >= 11.16, which has `npm stage`
+          registry-url: https://registry.npmjs.org
+      - run: npm install
+      - run: npm test
+      - run: npm stage publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`, which stages an npm publish whenever a GitHub release is published.

### How it works
- Triggered on `release: [published]`. (I used `published` rather than `created` deliberately: `created` does not fire when a draft release is later published, while `published` covers both releases created directly and drafts that get published.)
- Sets up Node from `.node-version` — Node 26 bundles npm 11.16, which ships the new `npm stage` command, so no separate npm upgrade step is needed.
- `npm install` runs the existing `prepare` script, so `dist/` (including the `.d.ts`/`.d.cts` files) is built before publishing; tests run as a final gate.
- `npm stage publish --provenance` stages the version on the registry instead of publishing it directly. The point of the staged flow is that CI needs no 2FA — proof-of-presence is deferred to a maintainer running `npm stage approve <stage-id>` (or approving in the npm UI), which is what actually publishes. `npm stage list` / `view` / `reject` / `download` are available for inspecting or discarding a staged version.
- Provenance attestation is enabled via the `id-token: write` permission.

### Setup needed before this works
- An **`NPM_TOKEN` repository secret** with publish rights for `sort-unwind`. If you'd rather use npm trusted publishing (OIDC) instead of a token, the `NODE_AUTH_TOKEN` env line should be dropped once the trusted publisher is configured on the package — happy to adjust.

Verified locally with npm 11.16: `npm stage publish --dry-run` packs the expected 9-file tarball (dist + README + LICENSE + package.json) and only fails on the already-published 3.1.0 version, as expected.

https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX)_