### PR TITLE
Release 4.0.0: drop Node 18/20, remove deprecated default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-06-11
+
+### Removed
+
+- **Breaking:** Removed the deprecated default export. Use the named import instead: `import { unwind } from 'sort-unwind'`.
+
 ### Changed
 
-- Bumped dev dependencies: `typescript` 5.9.3 → 6.0.3, `typescript-eslint` 8.59.3 → 8.59.4, `ts-jest` 29.4.9 → 29.4.11.
+- **Breaking:** Dropped support for Node 18 and 20 (both end-of-life); `engines` now requires Node >= 22.
+- Replaced jest with the built-in `node:test` runner, removing `jest`, `ts-jest`, `@types/jest`, and `eslint-plugin-jest`.
+- Simplified the eslint, tsconfig, tsup, and lint-staged configuration; added top-level `module`/`types` fields to `package.json`.
+- Bumped dev dependencies: `typescript` 5.9.3 → 6.0.3, `typescript-eslint` 8.59.3 → 8.59.4.
 - Added `ignoreDeprecations: "6.0"` to `tsconfig.json` to silence the `baseUrl` deprecation emitted by tsup's DTS build under TypeScript 6.
+- CI now tests on Node 22, 24, and 26.
+
+### Added
+
+- Release workflow that stages an npm publish (`npm stage publish`) when a GitHub release is published.
 
 ### Fixed
 
@@ -89,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/philihp/sort-unwind/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/philihp/sort-unwind/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/philihp/sort-unwind/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/philihp/sort-unwind/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/philihp/sort-unwind/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/philihp/sort-unwind/compare/v2.1.2...v3.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sort-unwind",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Sorts an array and then unwinds that sort on another array",
   "author": "Philihp Busby <philihp@gmail.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,3 @@ export const curried =
 // to just being one exported function with an optional second
 // param... but this is just simpler.
 export const unwind = <T>(rank: number[], src: T[]) => curried(rank)(src)
-
-// deprecated, will be removed in version 4
-export default unwind


### PR DESCRIPTION
## Summary

Bumps the version to **4.0.0** and prepares the changelog for release.

### Why a major bump
- `engines` now requires Node >= 22 (the 18/20 drop landed in #929) — this repo's changelog has historically treated Node support drops as breaking (see 2.0.0).
- The deprecated default export is **removed**, fulfilling the source comment that promised its removal in version 4. Consumers using `import unwind from 'sort-unwind'` must switch to the named import:

```js
import { unwind } from 'sort-unwind'
```

The README already documents only the named import, and the emitted types now export just `curried` and `unwind`.

### Changelog
The `[Unreleased]` section moves into a dated `[4.0.0]` entry that also records everything merged recently: the jest → `node:test` migration (#930), the config simplification and CI matrix update (#929), and the new staged-publish release workflow (#931). Compare links updated.

## Verification
- `npm test` — 8/8 passing (tests already used only named imports)
- `npm run lint`, `npx tsc --noEmit` — clean
- `npm run build` — `dist/index.d.ts` / `.d.cts` confirm the default export is gone

After merging, creating a GitHub release tagged `v4.0.0` will trigger the new release workflow, which stages the publish for your `npm stage approve`.

https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9miMhCvA6b3EYw979KpYX)_