### PR TITLE
refactor: derive derank as the sort permutation of indices

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { shuffle } from 'fast-shuffle'
-import { curried, unwind } from '../index.ts'
+import { unwind } from '../index.ts'
 
 describe('unwind', () => {
   it('accepts zero items', () => {
@@ -55,16 +55,25 @@ describe('unwind', () => {
     assert.notEqual(dederank, rank)
   })
 
-  it('can be curried', () => {
-    const reverse4 = curried([3, 2, 1, 0])
-    assert.doesNotThrow(() => {
-      const [reversed] = reverse4(['d', 'c', 'b', 'a'])
-      assert.deepEqual(reversed, ['a', 'b', 'c', 'd'])
-    })
-    assert.doesNotThrow(() => {
-      const [reversed] = reverse4(['d', 'd', 'b', 'b'])
-      assert.deepEqual(reversed, ['b', 'b', 'd', 'd'])
-    })
+  it('accepts duplicate values', () => {
+    const [reversed] = unwind([3, 2, 1, 0], ['d', 'd', 'b', 'b'])
+    assert.deepEqual(reversed, ['b', 'b', 'd', 'd'])
+  })
+
+  it('sorts stably when ranks are duplicated', () => {
+    const src = ['a', 'b', 'c', 'd']
+    const rank = [1, 0, 1, 0]
+    const [dst, derank] = unwind(rank, src)
+    assert.deepEqual(dst, ['b', 'd', 'a', 'c'])
+    assert.deepEqual(derank, [1, 3, 0, 2])
+  })
+
+  it('does not mutate the inputs', () => {
+    const src = ['b', 'c', 'a']
+    const rank = [1, 2, 0]
+    unwind(rank, src)
+    assert.deepEqual(src, ['b', 'c', 'a'])
+    assert.deepEqual(rank, [1, 2, 0])
   })
 
   it('allows ranks that are not zero-indexed integers', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { shuffle } from 'fast-shuffle'
-import { unwind } from '../index.ts'
+import { curried, unwind } from '../index.ts'
 
 describe('unwind', () => {
   it('accepts zero items', () => {
@@ -53,6 +53,18 @@ describe('unwind', () => {
     assert.deepEqual(dst, src)
     assert.notEqual(dst, src)
     assert.notEqual(dederank, rank)
+  })
+
+  it('can be curried', () => {
+    const reverse4 = curried([3, 2, 1, 0])
+    assert.doesNotThrow(() => {
+      const [reversed] = reverse4(['d', 'c', 'b', 'a'])
+      assert.deepEqual(reversed, ['a', 'b', 'c', 'd'])
+    })
+    assert.doesNotThrow(() => {
+      const [reversed] = reverse4(['d', 'd', 'b', 'b'])
+      assert.deepEqual(reversed, ['b', 'b', 'd', 'd'])
+    })
   })
 
   it('accepts duplicate values', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,5 @@
-export const curried =
-  (rank: number[]) =>
-  <T>(src: T[]): [T[], number[]] => {
-    if (src.length === 0) return [[], []]
-
-    const zipped: [number, number, any][] = []
-    src.forEach((_, i) => {
-      zipped.push([rank[i], i, src[i]])
-    })
-    // Array.sort will mutate the array, so we must make another
-    zipped.sort(([a], [b]) => a - b)
-
-    const dst: T[] = []
-    const derank: number[] = []
-    zipped.forEach(([_, i, o]) => {
-      derank.push(i)
-      dst.push(o)
-    })
-    return [dst, derank]
-  }
-
-// if i understood generics better, i think this could go back
-// to just being one exported function with an optional second
-// param... but this is just simpler.
-export const unwind = <T>(rank: number[], src: T[]) => curried(rank)(src)
+export const unwind = <T>(rank: number[], src: T[]): [T[], number[]] => {
+  // the derank is just the indices of src, sorted by their rank
+  const derank = [...src.keys()].sort((a, b) => rank[a] - rank[b])
+  return [derank.map((i) => src[i]), derank]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,8 @@ export const unwind = <T>(rank: number[], src: T[]): [T[], number[]] => {
   const derank = [...src.keys()].sort((a, b) => rank[a] - rank[b])
   return [derank.map((i) => src[i]), derank]
 }
+
+export const curried =
+  (rank: number[]) =>
+  <T>(src: T[]): [T[], number[]] =>
+    unwind(rank, src)


### PR DESCRIPTION
## What

Simplifies `unwind` down to its core insight: **the derank/tenet is exactly the array of `src` indices sorted by their rank**, and the sorted output is just that permutation applied to `src`.

```ts
export const unwind = <T>(rank: number[], src: T[]): [T[], number[]] => {
  // the derank is just the indices of src, sorted by their rank
  const derank = [...src.keys()].sort((a, b) => rank[a] - rank[b])
  return [derank.map((i) => src[i]), derank]
}
```

This collapses the zip-into-triples → sort → unzip dance into two lines:

- `[...src.keys()]` is a fresh array, so `Array.sort`'s mutation never touches the inputs
- the `src.length === 0` guard becomes unnecessary — the empty case falls out naturally as `[[], []]`
- the untyped `zipped: [number, number, any][]` tuple array is gone
- the roles of the two exports are flipped: `unwind(rank, src)` is now the single, fully generic implementation, and `curried` is a thin wrapper over it — which also retires the "if i understood generics better" comment

No API changes; both `unwind` and `curried` keep their existing signatures.

## Tests

Existing tests are unchanged. Three new cases: duplicate values, stable ordering when ranks are duplicated, and a check that neither input array is mutated. All 11 tests pass; lint and typecheck are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4oiJu1mxPQBgsjigdpb8